### PR TITLE
No rotation if rotation target is too near

### DIFF
--- a/Assets/Scripts/SpaceShip/Ship.cs
+++ b/Assets/Scripts/SpaceShip/Ship.cs
@@ -64,6 +64,10 @@ public class Ship : MonoBehaviour
         if (!Alive)
             return;
 
+        Vector3 distance = target - transform.position;
+        if (distance.magnitude < 1)
+            return;
+
         if (MoveAim.magnitude > 0)
         {
             TurnTarget = Vector3.zero;


### PR DESCRIPTION
Если курсор слишком близко к кораблю, корабль начинает поворачиваться по вертикали на курсор.
Чтобы этого не было, не поворачиваемся если мышь очень близко к кораблю